### PR TITLE
Feature/testshell/testscripts

### DIFF
--- a/TestShell/main.cpp
+++ b/TestShell/main.cpp
@@ -174,7 +174,7 @@ TEST(ShellTest, partialLBAWriteTest) {
 		.Times(150)
 		.WillRepeatedly(Return(VALID_VALUE));
 
-	string expected = "Done";
+	string expected = "PASS";
 	string actual = ts.partialLBAWrite(value);
 	EXPECT_EQ(expected, actual);
 }
@@ -196,7 +196,7 @@ TEST(ShellTest, writeReadAging) {
 	EXPECT_CALL(ssd, write(99, _))
 		.Times(200);
 
-	string expected = "Done";
+	string expected = "PASS";
 	string actual = ts.writeReadAging(value);
 	EXPECT_EQ(expected, actual);
 }

--- a/TestShell/main.cpp
+++ b/TestShell/main.cpp
@@ -130,6 +130,48 @@ TEST(ShellTest, fullReadTest) {
 	ts.fullRead();
 }
 
+TEST(ShellTest, fullWriteAndReadCompare) {
+	EXPECT_CALL(ssd, read(_))
+		.Times(100);
+
+	uint32_t address = VALID_ADDRESS;
+	string value = VALID_VALUE;
+
+	string expected = "Done";
+	string actual = ts.fullWriteAndReadCompare(address, value);
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(ShellTest, partialLBAWriteTest) {
+	MockSSD ssd;
+	TestShell ts{ &ssd };
+
+	EXPECT_CALL(ssd, write(_, _))
+		.Times(150);
+
+	EXPECT_CALL(ssd, read(_))
+		.Times(150);
+
+	string expected = "Done";
+	string actual = ts.partialLBAWrite(value);
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(ShellTest, writeReadAging) {
+	MockSSD ssd;
+	TestShell ts{ &ssd };
+
+	EXPECT_CALL(ssd, write(_, _))
+		.Times(40);
+
+	EXPECT_CALL(ssd, read(_))
+		.Times(40);
+
+	string expected = "Done";
+	string actual = ts.writeReadAging(value);
+	EXPECT_EQ(expected, actual);
+}
+
 int main(void) {
 	::testing::InitGoogleMock();
 	return RUN_ALL_TESTS();

--- a/TestShell/test_shell.cpp
+++ b/TestShell/test_shell.cpp
@@ -50,6 +50,65 @@ public:
 		}
 		return ret;
 	}
+
+	string fullWriteAndReadCompare() {
+
+		for (int groupStart = SSD_MINIMUM_ADDRESS; groupStart < SSD_MAXIMUM_ADDRESS; groupStart += 5) {
+			std::stringstream ss;
+			ss << std::hex << std::setw(2) << std::setfill('0') << groupStart;
+			string value = "0x123456" + ss.str();
+			if (groupWriteAndReadCompare(groupStart, groupStart + 5, value) == "FAIL") return "FAIL";
+		}
+
+		return "PASS";
+	}
+
+	string partialLBAWrite(string value) {
+		if (!isValidValue(value)) return "ERROR";
+
+		for (int i = 0; i < 30; i++)
+		{
+			ssd->write(4, value);
+			ssd->write(0, value);
+			ssd->write(3, value);
+			ssd->write(1, value);
+			ssd->write(2, value);
+
+			if (value != ssd->read(4)) return "ERROR";
+			if (value != ssd->read(0)) return "ERROR";
+			if (value != ssd->read(3)) return "ERROR";
+			if (value != ssd->read(1)) return "ERROR";
+			if (value != ssd->read(2)) return "ERROR";
+		}
+		return "Done";
+	}
+
+	string writeReadAging(string value) {
+		if (!isValidValue(value)) return "ERROR";
+
+		for (int i = 0; i < 200; i++)
+		{
+			ssd->write(0, value);
+			ssd->write(99, value);
+			if (ssd->read(0) != ssd->read(99))
+				return "ERROR";
+		}
+		return "Done";
+	}
+
+	string groupWriteAndReadCompare(int startAddr, int endAddr, string value) {
+
+		for (int addr = startAddr; addr < endAddr; addr++) {
+			ssd->write(addr, value);
+		}
+
+		for (int addr = startAddr; addr < endAddr; addr++) {
+			if (value != ssd->read(addr)) return "FAIL";
+		}
+
+		return "PASS";
+	}
+
 private:
 	SSD* ssd;
 	const int SSD_MINIMUM_ADDRESS = 0;
@@ -72,4 +131,6 @@ private:
 
 		return true;
 	}
+
+
 };


### PR DESCRIPTION
1. fullWriteAndReadCompare 함수는 구현 하였으나, 진행 과정에서 아래의 문제를 발견하였습니다. 
- 이 스크립트의 요구 사항에 따르면 5개의 addr 그룹들로 묶은 뒤, 각 그룹에는 다른 값을 write 하면서 수행해야 하는데, gmock 의 경우 이렇게 EXPECT_CALL 세팅이 잘 안 되는 것 같습니다. 예를 들어 지금 주석 처리된 fullWriteAndReadCompare 테스트 케이스의 경우,  5번의 read는 0x00000010 를 반환하고 5번의 read 은 0x00000011 을 반환하도록 하였으나, Times 함수가 이전의 내역을 reset 하는 것으로 보입니다. 
- 따라서 전체 full test 가 어려울 것 같아, 우선 5개의 그룹 단위로 테스트 할 수 있도록 groupWriteAndReadCompare 테스트 케이스를 추가하고, groupWriteAndReadCompare 함수를 추가하였습니다. 이 부분 관련하여 추가 개선 사항 있을지 한 번 리뷰 부탁드립니다. fullWriteAndReadCompare 함수 자체에 대한 TC는 없는 게 마음에 조금 걸리네요. 

2. partialLBAWriteTest 함수의 경우, 특정 Value 에 대해 Partial영역write 동작 구현하였습니다. 테스트 조건에 따라 0~4 address write  & read test 를 수행하였고, 각각 read 결과값은 write value 와 비교하였습니다. 4, 0, 3, 1, 2 순서를 무작위로 변경하는 경우는 고려하지 않았습니다.

3. writeReadAging Test 의 경우 Randum value 에 대하여 0과 99 address 에 write 후 read 하는 동작을 200회 반복 테스트 하는 Case 를 구현하였습니다. 현재 TEST에서는 Randum data 가 구현되어 있지 않아, Valid value 로 구현하였으며, 내부 function 에서는 value 의 valid 체크를 진행하여 정상 address 가 아닐 경우 return 하도록 구현하였습니다. 이에 expect_call 의 address를 각각 0과 99 로 특정하여 Times 체크를 수행하도록 TC 를 수정하였습니다.

