### PR TITLE
Feature/testshell/run with real ssd

### DIFF
--- a/TestShell/TestShell.vcxproj
+++ b/TestShell/TestShell.vcxproj
@@ -138,6 +138,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="interface.h" />
+    <ClInclude Include="real_ssd.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/TestShell/TestShell.vcxproj.filters
+++ b/TestShell/TestShell.vcxproj.filters
@@ -38,5 +38,8 @@
     <ClInclude Include="interface.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
+    <ClInclude Include="real_ssd.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/TestShell/main.cpp
+++ b/TestShell/main.cpp
@@ -1,6 +1,7 @@
 #include "gmock/gmock.h"
 #include "interface.h"
 #include "test_shell.cpp"
+#include "real_ssd.h"
 
 using namespace testing;
 
@@ -372,29 +373,25 @@ TEST(ShellTest, TestCase3_FullDoNotWorkTest) {
 	EXPECT_FALSE(actual);
 }
 
-TEST(ShellTest, readWithRealSSD) {
-	string command = "read";
-	TestShell ts;
+TEST(ShellTest, readWithRealSSDNoOutput) {
+
+	RealSSD ssd;
+	TestShell ts(&ssd);
 	uint32_t lba = VALID_ADDRESS;
 
-	ts.read(VALID_ADDRESS);
-
 	string expected = "0x00000000";
-	string actual;
+	string actual = ts.read(VALID_ADDRESS);
 
-	FILE* fp;
-	fp = fopen("ssd_output.txt", "r");
-	read(fp, &actual, 10);
 	EXPECT_EQ(expected, actual);
 }
 
 TEST(ShellTest, writeWithRealSSD) {
-	string command = "write";
-	TestShell ts;
+	RealSSD ssd;
+	TestShell ts(&ssd);
 	uint32_t lba = VALID_ADDRESS;
 	string value = VALID_VALUE;
 
-	string expected = "[Write] Done";
+	string expected = "Done";
 	string actual = ts.write(VALID_ADDRESS, VALID_VALUE);
 
 	EXPECT_EQ(expected, actual);

--- a/TestShell/main.cpp
+++ b/TestShell/main.cpp
@@ -372,6 +372,34 @@ TEST(ShellTest, TestCase3_FullDoNotWorkTest) {
 	EXPECT_FALSE(actual);
 }
 
+TEST(ShellTest, readWithRealSSD) {
+	string command = "read";
+	TestShell ts;
+	uint32_t lba = VALID_ADDRESS;
+
+	ts.read(VALID_ADDRESS);
+
+	string expected = "0x00000000";
+	string actual;
+
+	FILE* fp;
+	fp = fopen("ssd_output.txt", "r");
+	read(fp, &actual, 10);
+	EXPECT_EQ(expected, actual);
+}
+
+TEST(ShellTest, writeWithRealSSD) {
+	string command = "write";
+	TestShell ts;
+	uint32_t lba = VALID_ADDRESS;
+	string value = VALID_VALUE;
+
+	string expected = "[Write] Done";
+	string actual = ts.write(VALID_ADDRESS, VALID_VALUE);
+
+	EXPECT_EQ(expected, actual);
+}
+
 int main(void) {
 	::testing::InitGoogleMock();
 	return RUN_ALL_TESTS();

--- a/TestShell/real_ssd.h
+++ b/TestShell/real_ssd.h
@@ -5,8 +5,11 @@
 class RealSSD : public SSD {
 
 public:
+	RealSSD() {
+		exeDir = getExecutablePath();
+	}
+
 	string read(uint32_t address) {
-		std::string exeDir = getExecutablePath();
 		std::string command = exeDir + "/SSD.exe R " + std::to_string(address);
 
 		FILE* pipe = _popen(command.c_str(), "r");
@@ -34,7 +37,6 @@ public:
 	}
 
 	void write(uint32_t address, string value) {
-		std::string exeDir = getExecutablePath();
 		std::string command = exeDir + "/SSD.exe W " + std::to_string(address) + " " + value;
 		FILE* pipe = _popen(command.c_str(), "r");
 		if (pipe) {
@@ -43,6 +45,7 @@ public:
 	}
 
 private:
+	std::string exeDir;
 
 	std::string getExecutablePath() {
 		char path[MAX_PATH];

--- a/TestShell/real_ssd.h
+++ b/TestShell/real_ssd.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <windows.h>
+#include "interface.h"
+
+class RealSSD : public SSD {
+
+public:
+	string read(uint32_t address) {
+		std::string exeDir = getExecutablePath();
+		std::string command = exeDir + "/SSD.exe R " + std::to_string(address);
+
+		FILE* pipe = _popen(command.c_str(), "r");
+		if (!pipe) {
+			return "ERROR";
+		}
+
+		_pclose(pipe);
+		
+		FILE* file = nullptr;
+		errno_t err = fopen_s(&file, "ssd_output.txt", "r");
+
+		if (err != 0 || file == nullptr) {
+			return "0x00000000";
+		}
+
+		char buffer[256];  // Max line length
+		std::string firstLine = "";
+
+		if (fgets(buffer, sizeof(buffer), file)) {
+			firstLine = buffer;
+		}
+
+		return firstLine;
+	}
+
+	void write(uint32_t address, string value) {
+		std::string exeDir = getExecutablePath();
+		std::string command = exeDir + "/SSD.exe W " + std::to_string(address) + " " + value;
+		FILE* pipe = _popen(command.c_str(), "r");
+		if (pipe) {
+			_pclose(pipe);
+		}
+	}
+
+private:
+
+	std::string getExecutablePath() {
+		char path[MAX_PATH];
+		GetModuleFileNameA(NULL, path, MAX_PATH);
+		std::string exePath(path);
+		return exePath.substr(0, exePath.find_last_of("\\/"));
+	}
+};


### PR DESCRIPTION
SSD interface 를 상속받는 RealSSD class 를 추가하였습니다. 
- 현재 read 시 ssd.exe 를 system call 을 통해 실행은 하지만, ssd_output.txt 가 준비되지 않았으므로 0x00000000 을 리턴하도록 하고 이를 확인하는 테스트 케이스로 변경하였습니다. 
- write는 ssd.exe 를 실행시키지만, 정상 수행 여부는 판별하지 않습니다. 