### PR TITLE
bugfix: parameter parsing

### DIFF
--- a/SSD/ssd.cpp
+++ b/SSD/ssd.cpp
@@ -180,7 +180,7 @@ bool SSD::CheckValue(int argc, char* argv[], OUT unsigned int* pnValue)
     }
 
     char* end;
-    *pnValue = (unsigned int)strtol(argv[PARAM_VALUE], &end, 16);
+    *pnValue = (unsigned int)strtoul(argv[PARAM_VALUE], &end, 16);
     if (end != &argv[PARAM_VALUE][VALUE_INPUT_LENGTH]) {
         return false;
     }

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -212,3 +212,20 @@ TEST_F(SSDTestFixture, invalidValueTest)
     bool actual = ssd.isValidCheckAndCastType(argc, argv, &eCmd, &lba, &value);
     EXPECT_EQ(expected, actual);
 }
+
+TEST_F(SSDTestFixture, MixCapitalSmallTest)
+{
+    int argc = 4;
+    char* argv[5];
+    uint32_t lba;
+    uint32_t value;
+    CmdType eCmd;
+
+    argv[1] = const_cast<char*>("W");
+    argv[2] = const_cast<char*>("1");
+    argv[3] = const_cast<char*>("0xAaAaAaAa");
+
+    unsigned int expected = 0xaaaaaaaa;
+    ssd.isValidCheckAndCastType(argc, argv, &eCmd, &lba, &value);
+    EXPECT_EQ(expected, value);
+}


### PR DESCRIPTION
라이브러리 함수를 잘못 사용해서 0x7FFFFFFF를 초과하는 Value는 제대로 처리해주지 못하고 있었습니다.