### PR TITLE
refactoring: groupWrite moved to private and formatting applied

### DIFF
--- a/TestScript/1_FullWriteAndReadCompare.cpp
+++ b/TestScript/1_FullWriteAndReadCompare.cpp
@@ -1,7 +1,7 @@
+#include "Logger.h"
 #include "pch.h"
 #include "ssd_interface.h"
 #include "test_script_interface.h"
-#include "Logger.h"
 
 #include <iomanip>
 #include <iostream>
@@ -27,6 +27,9 @@ public:
         return "PASS";
     }
 
+private:
+    SSD* ssd;
+
     string groupWriteAndReadCompare(Logger* logger, int startAddr, int endAddr, string value)
     {
         for (int addr = startAddr; addr < endAddr; addr++) {
@@ -44,9 +47,6 @@ public:
         }
         return "PASS";
     }
-
-private:
-    SSD* ssd;
 };
 
 extern "C" __declspec(dllexport) ITestScript* CreateScript_1_(SSD* ssd)

--- a/TestScript/2_PartialLBAWrite.cpp
+++ b/TestScript/2_PartialLBAWrite.cpp
@@ -1,7 +1,7 @@
+#include "Logger.h"
 #include "pch.h"
 #include "ssd_interface.h"
 #include "test_script_interface.h"
-#include "Logger.h"
 
 #include <iostream>
 #include <vector>

--- a/TestScript/3_WriteReadAging.cpp
+++ b/TestScript/3_WriteReadAging.cpp
@@ -1,7 +1,7 @@
+#include "Logger.h"
 #include "pch.h"
 #include "ssd_interface.h"
 #include "test_script_interface.h"
-#include "Logger.h"
 
 #include <iomanip>
 #include <iostream>

--- a/TestScript/4_EraseAndWriteAging.cpp
+++ b/TestScript/4_EraseAndWriteAging.cpp
@@ -1,7 +1,7 @@
+#include "Logger.h"
 #include "pch.h"
 #include "ssd_interface.h"
 #include "test_script_interface.h"
-#include "Logger.h"
 
 #include <iostream>
 #include <vector>
@@ -26,7 +26,7 @@ public:
                 ssd->write(startAddr, "0x87654321");
 
                 if (logger != nullptr)
-                    logger->Print("4_EraseAndWriteAging.erase()", "erase value from " + std::to_string(startAddr) + " to " + std::to_string(startAddr+2));
+                    logger->Print("4_EraseAndWriteAging.erase()", "erase value from " + std::to_string(startAddr) + " to " + std::to_string(startAddr + 2));
                 ssd->erase(startAddr, 3);
 
                 if (didReadFail(ssd->read(startAddr), "0x00000000")) {
@@ -37,13 +37,13 @@ public:
 
                 if (didReadFail(ssd->read(startAddr + 1), "0x00000000")) {
                     if (logger != nullptr)
-                        logger->Print("4_EraseAndWriteAging.erase()", "value is not erased at " + std::to_string(startAddr+1));
+                        logger->Print("4_EraseAndWriteAging.erase()", "value is not erased at " + std::to_string(startAddr + 1));
                     return "FAIL";
                 }
 
                 if (didReadFail(ssd->read(startAddr + 2), "0x00000000")) {
                     if (logger != nullptr)
-                        logger->Print("4_EraseAndWriteAging.erase()", "value is not erased at " + std::to_string(startAddr+2));
+                        logger->Print("4_EraseAndWriteAging.erase()", "value is not erased at " + std::to_string(startAddr + 2));
                     return "FAIL";
                 }
             }


### PR DESCRIPTION
[TestScript/1_FullWriteAndReadCompare.cpp](https://github.com/JeongJonghwi/CRA-SSD/compare/refactoring/testscript/formatting?expand=1#diff-df0b17ae94b19a4b87ba69df22554adb771b67854f35bf88b05d439696322e82) 내의 groupWriteAndReadCompare 함수를 private으로 바꾸고, testscript 관련 파일 전체에 formatting을 적용하였습니다. 