### PR TITLE
refactoring: delete copy constructor and assignment operator for singleton

### DIFF
--- a/LoggerLib/Logger.h
+++ b/LoggerLib/Logger.h
@@ -8,6 +8,8 @@ using std::string;
 class Logger {
 public:
     virtual ~Logger();
+    Logger(const Logger& logger) = delete;
+    Logger& operator=(Logger& logger) = delete;
     void Print(const string& logingFunctionStr, const string& loggingMessage);
     void CloseLogger();
     static Logger& getInstance();


### PR DESCRIPTION
Logger singletone 적용을 위해서 불필요한 copy constructor와 assignment operator를 삭제했습니다.